### PR TITLE
version 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    narabikae (0.1.0)
+    narabikae (0.2.0)
       activerecord
       activesupport
       fractional_indexer

--- a/lib/narabikae/version.rb
+++ b/lib/narabikae/version.rb
@@ -1,3 +1,3 @@
 module Narabikae
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This pull request includes a small change to the `lib/narabikae/version.rb` file. The change updates the version number of the `Narabikae` module from `0.1.0` to `0.2.0`.

* [`lib/narabikae/version.rb`](diffhunk://#diff-00e5f761036246dc0a2d2378f8020a409b8d8b29d4fa12fa9a92a89ec9353285L2-R2): Updated the version number from `0.1.0` to `0.2.0`.