### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
This pull request includes a small but important change to the CI configuration file. The change updates the branch name from `master` to `main` to align with modern naming conventions.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL6-R6): Updated the branch name from `master` to `main` in the CI workflow configuration.