### PR TITLE
Update task order in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Task.create([
           { name: 'task-3' }
      ])
 Task.order(:position).pluck(:name, :position)
-# => [["task-1", "a0"], ["task-3", "a1"], ["task-1", "a2"]]
+# => [["task-1", "a0"], ["task-2", "a1"], ["task-3", "a2"]]
 
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects the expected output of the `Task.order(:position).pluck(:name, :position)` method to reflect the correct order of tasks.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84): Corrected the expected output of `Task.order(:position).pluck(:name, :position)` to show the correct order of tasks.