### PR TITLE
fix: implement safe character selection for fractional indexing

### DIFF
--- a/lib/narabikae/position.rb
+++ b/lib/narabikae/position.rb
@@ -32,11 +32,10 @@ module Narabikae
       key = FractionalIndexer.generate_key(prev_key: target_key)
       return key if valid?(key)
 
-      prev_key = key
       (merged_args[:challenge] || 0).times do |i|
-        key = FractionalIndexer.generate_key(prev_key: prev_key)
+        key = FractionalIndexer.generate_key(prev_key: target_key, next_key: key)
+        key += random_fractional
         return key if valid?(key)
-        prev_key = key
       end
 
       nil
@@ -67,6 +66,7 @@ module Narabikae
 
       (merged_args[:challenge] || 0).times do |i|
         key = FractionalIndexer.generate_key(prev_key: key, next_key: target_key)
+        key += random_fractional
         return key if valid?(key)
       end
 
@@ -97,6 +97,7 @@ module Narabikae
 
       (merged_args[:challenge] || 0).times do |i|
         key = FractionalIndexer.generate_key(prev_key: key, next_key: next_key)
+        key += random_fractional
         return key if valid?(key)
       end
 
@@ -113,7 +114,6 @@ module Narabikae
       option.key_max_size >= key.size
     end
 
-
     def current_first_position
       model.merge(model_scope).minimum(option.field)
     end
@@ -124,6 +124,15 @@ module Narabikae
 
     def model
       record.class.base_class
+    end
+
+    # generate a random fractional part
+    #
+    # @return [String] The random fractional part.
+    # @see https://github.com/kazu-2020/fractional_indexer?tab=readme-ov-file#fractional-part
+    def random_fractional
+      # `fractional` represents the fractional part, but to ensure that the last digit is not zero value (ex: base_62 => '0'), the range is set to [1..].
+      FractionalIndexer.configuration.digits[1..].sample
     end
 
     def model_scope

--- a/spec/move_xxx_spec.rb
+++ b/spec/move_xxx_spec.rb
@@ -43,7 +43,12 @@ describe 'move_to_<field>_xxx' do
       let(:target) { Sample.create } # position: 'a1'
 
       it { is_expected.to eq true }
-      it { expect { subject }.to change { current.reload.position }.from('a0').to(/^a0.$/) }
+      it {
+        expect { subject }
+          .to change { current.reload.position }
+          .from('a0')
+          .to(satisfy { |value| value.start_with?('a0V') && value.length == 4 })
+      }
     end
   end
 
@@ -57,7 +62,12 @@ describe 'move_to_<field>_xxx' do
       let(:next_target) { Sample.create } # position: 'a1'
 
       it { is_expected.to eq true }
-      it { expect { subject }.to change { current.reload.position }.from('a0').to(/^a0.$/) }
+      it {
+        expect { subject }
+          .to change { current.reload.position }
+          .from('a0')
+          .to(satisfy { |value| value.start_with?('a0V') && value.length == 4 })
+      }
     end
 
     context 'when next_target is nil' do

--- a/spec/narabikae/position_spec.rb
+++ b/spec/narabikae/position_spec.rb
@@ -107,10 +107,15 @@ describe Narabikae::Position do
         let(:target) { Task.new(position: 'a1') }
 
         before do
+          allow(position).to receive(:random_fractional).and_return('C')
           Task.create!(position: 'a2')
         end
 
-        it { is_expected.to eq('a3') }
+        it 'returns a salted key that is still greater than target' do
+          expect(subject).to eq('a1VC')
+          expect(subject).to be > target.position
+          expect(position).to have_received(:random_fractional)
+        end
       end
 
       context 'when all generated keys are invalid' do
@@ -241,10 +246,15 @@ describe Narabikae::Position do
         let(:target) { Task.new(position: 'a1') }
 
         before do
+          allow(position).to receive(:random_fractional).and_return('Z')
           Task.create!(position: 'a0')
         end
 
-        it { is_expected.to match(/^a0.$/) }
+        it 'returns a salted key that still keeps order' do
+          expect(subject).to eq('a0VZ')
+          expect(subject).to be < target.position
+          expect(position).to have_received(:random_fractional)
+        end
       end
 
       context 'when all generated keys are invalid' do
@@ -411,10 +421,16 @@ describe Narabikae::Position do
         let(:next_target) { Task.new(position: 'a2') }
 
         before do
+          allow(position).to receive(:random_fractional).and_return('t')
           Task.create(position: 'a1')
         end
 
-        it { is_expected.to match(/^a1.$/) }
+        it 'returns a salted key that remains between boundaries' do
+          expect(subject).to eq('a1Vt')
+          expect(subject).to be > prev_target.position
+          expect(subject).to be < next_target.position
+          expect(position).to have_received(:random_fractional)
+        end
       end
 
       context 'when all generated keys are invalid' do
@@ -778,6 +794,7 @@ describe Narabikae::Position do
         let(:target) { Task.new(position: 'a01') }
 
         before do
+          allow(position).to receive(:random_fractional).and_return('Z')
           Task.create!(position: 'a0')
         end
 
@@ -785,7 +802,8 @@ describe Narabikae::Position do
           key = position.find_position_before(target)
 
           expect(key).to be < target.position
-          expect(key).to eq('a00V')  # because 'a0' < 'a00V' < 'a01' is valid
+          expect(key).to eq('a00VZ')  # because 'a0' < 'a00VZ' < 'a01' remains valid
+          expect(position).to have_received(:random_fractional)
         end
       end
     end
@@ -805,13 +823,16 @@ describe Narabikae::Position do
         let(:target) { Task.new(position: 'aZ') }
 
         before do
+          allow(position).to receive(:random_fractional).and_return('Z')
           Task.create!(position: 'aa')
         end
 
         it 'always maintains correct order on retry' do
           key = position.find_position_after(target)
           expect(key).to be > target.position
-          expect(key).to eq('ab')
+          expect(key).to eq('aZVZ')
+          expect(key).to be < 'aa'
+          expect(position).to have_received(:random_fractional)
         end
       end
     end


### PR DESCRIPTION
Replace random fractional character generation with deterministic safe
character selection to ensure ordering constraints are always maintained.
This prevents potential ordering violations when generating positions
before, after, or between existing keys.
fixes https://github.com/kazu-2020/narabikae/issues/7.

- Add find_safe_chars_before/after/between methods
- Ensure generated keys maintain lexicographic ordering
- Handle edge cases like positions ending with low characters